### PR TITLE
Alt+F4を使えるようにする

### DIFF
--- a/Source.cpp
+++ b/Source.cpp
@@ -1703,7 +1703,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             }
             return 0;
         }
-        if (wParam != VK_LEFT && wParam != VK_RIGHT && wParam != VK_F4) return DefWindowProc(hwnd, msg, wParam, lParam);
+        if (wParam != VK_LEFT && wParam != VK_RIGHT) return DefWindowProc(hwnd, msg, wParam, lParam);
         break;
     case WM_KEYDOWN:
         if (GetKeyState(VK_CONTROL) & 0x8000) {


### PR DESCRIPTION
Alt+F4は、「ウィンドウを閉じる」ためのWindows標準のキーバインドであり、特に理由がなければ変更すべきではありません。

変更前：Alt+F4を押してもウィンドウが閉じない。
変更後：Alt+F4を押すとウィンドウが閉じる。

参考:
https://learn.microsoft.com/ja-jp/windows/win32/learnwin32/closing-the-window
